### PR TITLE
tweak: dev in containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,15 @@ directory. This should start all dependencies and services.
 
 `metis-gui` should be available at `http://localhost:10000/`
 
-`metis-bff` shoult be available at `http://localhost:10000/api`
+`metis-bff` shoult be available at `http://localhost:3000/`
+
+For development you can start services with overrides. For example, if you want
+start `metis-backend` in dev mode, run
+`docker-compose -f compose.yml -f compose.dev-backend.yml up`.
+If you want start `metis-bff` in dev mode, run
+`docker-compose -f compose.yml -f compose.dev-bff.yml up`.
+You can combine modes:
+`docker-compose -f compose.yml -f compose.dev-backend.yml -f compose.dev-bff.yml up`.
 
 ## License
 

--- a/compose.dev-backend.yml
+++ b/compose.dev-backend.yml
@@ -1,0 +1,5 @@
+services:
+  metis-backend:
+    volumes:
+      - .docker/s6-rc.d:/etc/s6-overlay/s6-rc.d
+      - .:/app

--- a/compose.dev-bff.yml
+++ b/compose.dev-bff.yml
@@ -1,0 +1,5 @@
+services:
+  metis-bff:
+    volumes:
+      - ../metis-bff:/app
+    entrypoint: "npm run dev"

--- a/compose.yml
+++ b/compose.yml
@@ -76,10 +76,8 @@ services:
       - yanode-pubkeys:/yanode-put-pubkey-here
       # auto add yanode:
       - .docker/empty:/etc/s6-overlay/s6-rc.d/user/contents.d/yascheduler-add-node
-      # - .docker/s6-rc.d:/etc/s6-overlay/s6-rc.d
-      # - .:/app
     ports:
-      - "10002:7050"
+      - "7050:7050"
     healthcheck:
       test: curl http://localhost:7050/calculations/template
       interval: 5s
@@ -106,12 +104,10 @@ services:
       API_KEY: *apikey
       # TODO: WEBHOOKS_KEY
     ports:
-      - "10001:3000"
-    # volumes:
-    #   - ../metis-bff:/app
+      - "3000:3000"
 
-  metis-frontend:
-    container_name: metis-frontend
+  metis-gui:
+    container_name: metis-gui
     depends_on: ["metis-bff"]
     build:
       context: ../metis-gui
@@ -126,8 +122,6 @@ services:
         }
     ports:
       - "10000:8080"
-    # volumes:
-    #   - ../metis-frontent/dist:/srv
 
   yanode:
     image: docker.io/linuxserver/openssh-server:latest


### PR DESCRIPTION
The idea:

Start services on default ports. So, backend at 7050 and bff at 3000.

`compose.yml` is some generic compose file to just start services in some demo mode. Not to develop.

To start `metis-backend` and/or `metis-bff` in dev mode, just combine compose files (generic + overrides) - see `README.md`.

Development of `metis-gui` in container is kinda pointless as it's a frontend. Gui in container starts at 10000 port. If you want to develop, just start `npm start dev` outside of containers and connect to default 5000 port. 