### PR TITLE
Fix race condition in docker compose init

### DIFF
--- a/.docker/yanode/custom-cont-init.d/gcompat.sh
+++ b/.docker/yanode/custom-cont-init.d/gcompat.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-apk add gcompat
+apk list -I | grep gcompat- || apk add gcompat

--- a/.docker/yanode/s6-rc.d/wait-pubkey/run
+++ b/.docker/yanode/s6-rc.d/wait-pubkey/run
@@ -1,0 +1,10 @@
+#!/usr/bin/with-contenv bash
+# shellcheck shell=bash
+
+# wait for public key
+if [ -d "$PUBLIC_KEY_DIR" ]; then
+    while [ -z "$(ls -A "$PUBLIC_KEY_DIR")" ]; do
+        echo "$PUBLIC_KEY_DIR is empty"
+        sleep 1
+    done
+fi

--- a/.docker/yanode/s6-rc.d/wait-pubkey/type
+++ b/.docker/yanode/s6-rc.d/wait-pubkey/type
@@ -1,0 +1,1 @@
+oneshot

--- a/.docker/yanode/s6-rc.d/wait-pubkey/up
+++ b/.docker/yanode/s6-rc.d/wait-pubkey/up
@@ -1,0 +1,1 @@
+/etc/s6-overlay/s6-rc.d/wait-pubkey/run

--- a/compose.yml
+++ b/compose.yml
@@ -137,8 +137,10 @@ services:
     sysctls:
       - "net.ipv4.ip_unprivileged_port_start=0"
     volumes:
-      - .docker/yanode/s6-rc.d/svc-openssh-server/run:/etc/s6-overlay/s6-rc.d/svc-openssh-server/run
-      - .docker/yanode/custom-cont-init.d:/custom-cont-init.d
+      - .docker/empty:/etc/s6-overlay/s6-rc.d/init-config/dependencies.d/wait-pubkey:ro
+      - .docker/yanode/s6-rc.d/wait-pubkey:/etc/s6-overlay/s6-rc.d/wait-pubkey:ro
+      - .docker/yanode/s6-rc.d/svc-openssh-server/run:/etc/s6-overlay/s6-rc.d/svc-openssh-server/run:ro
+      - .docker/yanode/custom-cont-init.d:/custom-cont-init.d:ro
       - yanode-host-keys:/config/ssh_host_keys
       - yanode-pubkeys:/pubkeys
       - yanode-data:/config/data


### PR DESCRIPTION
`yanode` now waits for public ssh keys in the shared volume.