### PR TITLE
docker compose tweaks

### DIFF
--- a/.docker/common.yml
+++ b/.docker/common.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_DB: &dbname metis
       POSTGRESQL_POSTGRES_PASSWORD: *dbpassword
     volumes:
-      - ./.docker/db/pgcrypto.sql:/docker-entrypoint-initdb.d/10-pgcrypto.sql
+      - db-data:/var/lib/postgresql/data
     healthcheck:
       test: pg_isready -U metis
       interval: 5s
@@ -56,8 +56,8 @@ services:
       YASCHEDULER_ADD_NODE_HOST: yanode
       YASCHEDULER_ADD_NODE_USER: user
     volumes:
-      # auto add yanode:
-      - .docker/empty:/etc/s6-overlay/s6-rc.d/user/contents.d/yascheduler-add-node
+      - metis-backend-home:/root
+      - metis-data:/data
     ports:
       - "7050:7050"
     healthcheck:
@@ -113,10 +113,5 @@ services:
       - PORT=22
     sysctls:
       - "net.ipv4.ip_unprivileged_port_start=0"
-    volumes:
-      - .docker/empty:/etc/s6-overlay/s6-rc.d/init-config/dependencies.d/wait-pubkey:ro
-      - .docker/yanode/s6-rc.d/wait-pubkey:/etc/s6-overlay/s6-rc.d/wait-pubkey:ro
-      - .docker/yanode/s6-rc.d/svc-openssh-server/run:/etc/s6-overlay/s6-rc.d/svc-openssh-server/run:ro
-      - .docker/yanode/custom-cont-init.d:/custom-cont-init.d:ro
     ports:
       - "10022:2222"

--- a/.docker/common.yml
+++ b/.docker/common.yml
@@ -33,8 +33,6 @@ services:
 
   metis-backend:
     container_name: metis-backend
-    build:
-      context: .
     environment:
       PGDATABASE: *dbname
       PGHOST: db
@@ -75,8 +73,6 @@ services:
         condition: service_healthy
       metis-backend:
         condition: service_healthy
-    build:
-      context: ../metis-bff
     environment:
       PG_NAME: *dbname
       PG_HOST: db

--- a/.docker/common.yml
+++ b/.docker/common.yml
@@ -1,0 +1,126 @@
+---
+version: "3.9"
+services:
+  db:
+    container_name: metis-db
+    image: docker.io/library/postgres:14
+    environment:
+      POSTGRES_USER: &dbuser metis
+      POSTGRES_PASSWORD: &dbpassword password
+      POSTGRES_DB: &dbname metis
+      POSTGRESQL_POSTGRES_PASSWORD: *dbpassword
+    volumes:
+      - ./.docker/db/pgcrypto.sql:/docker-entrypoint-initdb.d/10-pgcrypto.sql
+    healthcheck:
+      test: pg_isready -U metis
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  rabbitmq:
+    container_name: metis-rmq
+    image: docker.io/library/rabbitmq:3.8.14-management
+    environment:
+      RABBITMQ_DEFAULT_USER: &rabbituser guest
+      RABBITMQ_DEFAULT_PASS: &rabbitpass guest
+    volumes:
+      - rmq-data:/var/lib/rabbitmq/
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 30s
+      timeout: 30s
+      retries: 5
+
+  metis-backend:
+    container_name: metis-backend
+    build:
+      context: .
+    environment:
+      PGDATABASE: *dbname
+      PGHOST: db
+      PGPASSWORD: *dbpassword
+      PGUSER: *dbuser
+      RMQHOST: rabbitmq
+      RMQPASSWORD: *rabbitpass
+      RMQUSER: *rabbituser
+      TZ: Europe/Berlin
+      USER_EMAIL: aiida@localhost
+      USER_FIRST_NAME: Giuseppe
+      USER_LAST_NAME: Verdi
+      USER_INSTITUTION: LaScala
+      HOST: "0.0.0.0"
+      API_KEY: &apikey a-very-very-very-long-and-very-very-very-secret-string
+      WEBHOOKS_KEY: &webhookskey another-very-very-long-and-very-very-very-secret-string
+      WEBHOOKS_CALC_UPDATE: http://metis-bff:3000/v0/webhooks/calc_update
+      WEBHOOKS_CALC_CREATE: http://metis-bff:3000/v0/webhooks/calc_create
+      YASCHEDULER_DUMMY_ENGINE_URL: https://github.com/tilde-lab/dummy-engine/releases/download/v0.0.3/dummyengine
+      YASCHEDULER_LOCAL_DATA_DIR: "/data"
+      YASCHEDULER_ADD_NODE_HOST: yanode
+      YASCHEDULER_ADD_NODE_USER: user
+    volumes:
+      # auto add yanode:
+      - .docker/empty:/etc/s6-overlay/s6-rc.d/user/contents.d/yascheduler-add-node
+    ports:
+      - "7050:7050"
+    healthcheck:
+      test: curl http://localhost:7050/calculations/template
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  metis-bff:
+    container_name: metis-bff
+    depends_on:
+      db:
+        condition: service_healthy
+      metis-backend:
+        condition: service_healthy
+    build:
+      context: ../metis-bff
+    environment:
+      PG_NAME: *dbname
+      PG_HOST: db
+      PG_USER: *dbuser
+      PG_PASSWORD: *dbpassword
+      API_SCHEMA: http
+      API_HOST: metis-backend
+      API_PORT: "7050"
+      API_KEY: *apikey
+      # TODO: WEBHOOKS_KEY
+    ports:
+      - "3000:3000"
+
+  metis-gui:
+    container_name: metis-gui
+    environment:
+      PORT: "8080"
+      FORCE_HTTPS: "0"
+      PROXY_BFF_API_URL: "http://metis-bff:3000"
+      METIS_RUNTIME_CONFIG: |
+        {
+          'API_HOST': location.origin.concat('/api'),
+          'IDPS': ['local'],
+        }
+    ports:
+      - "10000:8080"
+
+  yanode:
+    image: docker.io/linuxserver/openssh-server:latest
+    container_name: yanode
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - PUBLIC_KEY_DIR=/pubkeys
+      - SUDO_ACCESS=true
+      - PASSWORD_ACCESS=false
+      - USER_NAME=user
+      - PORT=22
+    sysctls:
+      - "net.ipv4.ip_unprivileged_port_start=0"
+    volumes:
+      - .docker/empty:/etc/s6-overlay/s6-rc.d/init-config/dependencies.d/wait-pubkey:ro
+      - .docker/yanode/s6-rc.d/wait-pubkey:/etc/s6-overlay/s6-rc.d/wait-pubkey:ro
+      - .docker/yanode/s6-rc.d/svc-openssh-server/run:/etc/s6-overlay/s6-rc.d/svc-openssh-server/run:ro
+      - .docker/yanode/custom-cont-init.d:/custom-cont-init.d:ro
+    ports:
+      - "10022:2222"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
+.docker/common.yml
 .docker/db
 Dockerfile
 compose.yml
+compose.*.yml
 backups

--- a/README.md
+++ b/README.md
@@ -65,14 +65,7 @@ directory. This should start all dependencies and services.
 
 `metis-gui` should be available at `http://localhost:10000/`
 
-`metis-bff` shoult be available at `http://localhost:3000/`
-
-For development you can start services with overrides. For example, if you want, start `metis-backend` in dev mode, run
-`docker-compose -f compose.yml -f compose.dev-backend.yml up`.
-If you want, start `metis-bff` in dev mode, run
-`docker-compose -f compose.yml -f compose.dev-bff.yml up`.
-You can combine modes:
-`docker-compose -f compose.yml -f compose.dev-backend.yml -f compose.dev-bff.yml up`.
+`metis-bff` should be available at `http://localhost:3000/`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ One by one, all the parts are managed as follows:
 This is an experimental feature intended primarily for development and testing.
 
 It is assumed that you have the `metis-backend`, `metis-bff`, and `metis-gui`
-repositories cloned on the same level. Also, you need `docker` and `docker-compose`
-(or `podman` and `podman-compose`) installed.
+repositories cloned on the same level. Also, you need `docker` (or `podman`
+and `podman-compose`) installed.
 
-Now, you can run `docker-compose up` (`podman-compose up`) in `metis-backend`
+Now, you can run `docker compose up` (`podman-compose up`) in `metis-backend`
 directory. This should start all dependencies and services.
 
 `metis-gui` should be available at `http://localhost:10000/`

--- a/compose.dev-backend.yml
+++ b/compose.dev-backend.yml
@@ -1,5 +1,0 @@
-services:
-  metis-backend:
-    volumes:
-      - .docker/s6-rc.d:/etc/s6-overlay/s6-rc.d
-      - .:/app

--- a/compose.dev-bff.yml
+++ b/compose.dev-bff.yml
@@ -1,8 +1,0 @@
-services:
-  metis-bff:
-    build:
-      args:
-        - NODE_ENV=development
-    volumes:
-      - ../metis-bff:/app
-    entrypoint: "npm run dev"

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,0 +1,4 @@
+---
+version: "3.9"
+services: {}
+# there is no production version ha ha

--- a/compose.yml
+++ b/compose.yml
@@ -20,6 +20,8 @@ services:
     extends:
       file: .docker/common.yml
       service: metis-backend
+    build:
+      context: .
     depends_on:
       db:
         condition: service_healthy
@@ -37,6 +39,7 @@ services:
     build:
       args:
         - NODE_ENV=development
+      context: ../metis-bff
     depends_on:
       db:
         condition: service_healthy

--- a/compose.yml
+++ b/compose.yml
@@ -2,21 +2,12 @@
 version: "3.9"
 services:
   db:
-    container_name: metis-db
-    image: docker.io/library/postgres:14
-    environment:
-      POSTGRES_USER: &dbuser metis
-      POSTGRES_PASSWORD: &dbpassword password
-      POSTGRES_DB: &dbname metis
-      POSTGRESQL_POSTGRES_PASSWORD: *dbpassword
+    extends:
+      file: .docker/common.yml
+      service: db
     volumes:
       - ./.docker/db/pgcrypto.sql:/docker-entrypoint-initdb.d/10-pgcrypto.sql
       - db-data:/var/lib/postgresql/data
-    healthcheck:
-      test: pg_isready -U metis
-      interval: 5s
-      timeout: 5s
-      retries: 10
 
   adminer:
     container_name: metis-adminer
@@ -26,106 +17,51 @@ services:
       - "10003:8080"
 
   metis-backend:
-    container_name: metis-backend
+    extends:
+      file: .docker/common.yml
+      service: metis-backend
     depends_on:
       db:
         condition: service_healthy
-      # rabbitmq:
-      #   condition: service_healthy
-    build:
-      context: .
-    environment:
-      PGDATABASE: *dbname
-      PGHOST: db
-      PGPASSWORD: *dbpassword
-      PGUSER: *dbuser
-      TZ: Europe/Berlin
-      HOST: "0.0.0.0"
-      API_KEY: &apikey a-very-very-very-long-and-very-very-very-secret-string
-      WEBHOOKS_KEY: &webhookskey another-very-very-long-and-very-very-very-secret-string
-      WEBHOOKS_CALC_UPDATE: http://metis-bff:3000/v0/webhooks/calc_update
-      WEBHOOKS_CALC_CREATE: http://metis-bff:3000/v0/webhooks/calc_create
-      YASCHEDULER_DUMMY_ENGINE_URL: https://github.com/tilde-lab/dummy-engine/releases/download/v0.0.3/dummyengine
-      YASCHEDULER_LOCAL_DATA_DIR: "/data"
-      YASCHEDULER_ADD_NODE_HOST: yanode
-      YASCHEDULER_ADD_NODE_USER: user
     volumes:
+      - .docker/s6-rc.d:/etc/s6-overlay/s6-rc.d
+      - .:/app
       - metis-backend-home:/root
       - metis-data:/data
       - yanode-pubkeys:/yanode-put-pubkey-here
-      # auto add yanode:
-      - .docker/empty:/etc/s6-overlay/s6-rc.d/user/contents.d/yascheduler-add-node
-    ports:
-      - "7050:7050"
-    healthcheck:
-      test: curl http://localhost:7050/calculations/template
-      interval: 5s
-      timeout: 5s
-      retries: 10
 
   metis-bff:
-    container_name: metis-bff
+    extends:
+      file: .docker/common.yml
+      service: metis-bff
+    build:
+      args:
+        - NODE_ENV=development
     depends_on:
       db:
         condition: service_healthy
       metis-backend:
         condition: service_healthy
-    build:
-      context: ../metis-bff
-    environment:
-      PG_NAME: *dbname
-      PG_HOST: db
-      PG_USER: *dbuser
-      PG_PASSWORD: *dbpassword
-      API_SCHEMA: http
-      API_HOST: metis-backend
-      API_PORT: "7050"
-      API_KEY: *apikey
-      # TODO: WEBHOOKS_KEY
-    ports:
-      - "3000:3000"
+    volumes:
+      - ../metis-bff:/app
+    entrypoint: "npm run dev"
 
   metis-gui:
-    container_name: metis-gui
+    extends:
+      file: .docker/common.yml
+      service: metis-gui
     depends_on: ["metis-bff"]
     build:
       context: ../metis-gui
-    environment:
-      PORT: "8080"
-      FORCE_HTTPS: "0"
-      PROXY_BFF_API_URL: "http://metis-bff:3000"
-      METIS_RUNTIME_CONFIG: |
-        {
-          'API_HOST': location.origin.concat('/api'),
-          'IDPS': ['local'],
-        }
-    ports:
-      - "10000:8080"
 
   yanode:
-    image: docker.io/linuxserver/openssh-server:latest
-    container_name: yanode
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - PUBLIC_KEY_DIR=/pubkeys
-      - SUDO_ACCESS=true
-      - PASSWORD_ACCESS=false
-      - USER_NAME=user
-      - PORT=22
-    sysctls:
-      - "net.ipv4.ip_unprivileged_port_start=0"
+    extends:
+      file: .docker/common.yml
+      service: yanode
     volumes:
-      - .docker/empty:/etc/s6-overlay/s6-rc.d/init-config/dependencies.d/wait-pubkey:ro
-      - .docker/yanode/s6-rc.d/wait-pubkey:/etc/s6-overlay/s6-rc.d/wait-pubkey:ro
-      - .docker/yanode/s6-rc.d/svc-openssh-server/run:/etc/s6-overlay/s6-rc.d/svc-openssh-server/run:ro
-      - .docker/yanode/custom-cont-init.d:/custom-cont-init.d:ro
       - yanode-host-keys:/config/ssh_host_keys
       - yanode-pubkeys:/pubkeys
       - yanode-data:/config/data
-    ports:
-      - "10022:2222"
-
 
 volumes:
   db-data: {}

--- a/compose.yml
+++ b/compose.yml
@@ -7,7 +7,6 @@ services:
       service: db
     volumes:
       - ./.docker/db/pgcrypto.sql:/docker-entrypoint-initdb.d/10-pgcrypto.sql
-      - db-data:/var/lib/postgresql/data
 
   adminer:
     container_name: metis-adminer
@@ -28,9 +27,9 @@ services:
     volumes:
       - .docker/s6-rc.d:/etc/s6-overlay/s6-rc.d
       - .:/app
-      - metis-backend-home:/root
-      - metis-data:/data
       - yanode-pubkeys:/yanode-put-pubkey-here
+      # auto add yanode:
+      - .docker/empty:/etc/s6-overlay/s6-rc.d/user/contents.d/yascheduler-add-node
 
   metis-bff:
     extends:
@@ -67,6 +66,10 @@ services:
       file: .docker/common.yml
       service: yanode
     volumes:
+      - .docker/empty:/etc/s6-overlay/s6-rc.d/init-config/dependencies.d/wait-pubkey:ro
+      - .docker/yanode/s6-rc.d/wait-pubkey:/etc/s6-overlay/s6-rc.d/wait-pubkey:ro
+      - .docker/yanode/s6-rc.d/svc-openssh-server/run:/etc/s6-overlay/s6-rc.d/svc-openssh-server/run:ro
+      - .docker/yanode/custom-cont-init.d:/custom-cont-init.d:ro
       - yanode-host-keys:/config/ssh_host_keys
       - yanode-pubkeys:/pubkeys
       - yanode-data:/config/data

--- a/compose.yml
+++ b/compose.yml
@@ -56,6 +56,11 @@ services:
     depends_on: ["metis-bff"]
     build:
       context: ../metis-gui
+    environment:
+      METIS_RUNTIME_CONFIG_SRC: "/srv/index_html.orig"
+    volumes:
+      - ../metis-gui/dist/index.html:/srv/index_html.orig
+      - ../metis-gui/dist/build:/srv/build
 
   yanode:
     extends:

--- a/compose.yml
+++ b/compose.yml
@@ -28,8 +28,6 @@ services:
       - .docker/s6-rc.d:/etc/s6-overlay/s6-rc.d
       - .:/app
       - yanode-pubkeys:/yanode-put-pubkey-here
-      # auto add yanode:
-      - .docker/empty:/etc/s6-overlay/s6-rc.d/user/contents.d/yascheduler-add-node
 
   metis-bff:
     extends:


### PR DESCRIPTION
Move all reusable service definitions to `.docker/common.yml`.
`compose.yml` rebuild all images and use "dev" versions by default.
Remove compose overrides.