### PR TITLE
build(compose): dynamic container names

### DIFF
--- a/.docker/common.yml
+++ b/.docker/common.yml
@@ -2,7 +2,6 @@
 version: "3.9"
 services:
   db:
-    container_name: metis-db
     image: docker.io/library/postgres:14
     environment:
       POSTGRES_USER: &dbuser metis
@@ -18,7 +17,6 @@ services:
       retries: 10
 
   rabbitmq:
-    container_name: metis-rmq
     image: docker.io/library/rabbitmq:3.8.14-management
     environment:
       RABBITMQ_DEFAULT_USER: &rabbituser guest
@@ -32,7 +30,6 @@ services:
       retries: 5
 
   metis-backend:
-    container_name: metis-backend
     environment:
       PGDATABASE: *dbname
       PGHOST: db
@@ -67,7 +64,6 @@ services:
       retries: 10
 
   metis-bff:
-    container_name: metis-bff
     depends_on:
       db:
         condition: service_healthy
@@ -87,7 +83,6 @@ services:
       - "3000:3000"
 
   metis-gui:
-    container_name: metis-gui
     environment:
       PORT: "8080"
       FORCE_HTTPS: "0"
@@ -102,7 +97,6 @@ services:
 
   yanode:
     image: docker.io/linuxserver/openssh-server:latest
-    container_name: yanode
     environment:
       - PUID=1000
       - PGID=1000

--- a/.docker/s6-rc.d/yascheduler-add-node/up
+++ b/.docker/s6-rc.d/yascheduler-add-node/up
@@ -6,4 +6,4 @@ if { s6-test -v YASCHEDULER_ADD_NODE_HOST }
 importas HOST YASCHEDULER_ADD_NODE_HOST
 importas -D "root" USERNAME YASCHEDULER_ADD_NODE_USER
 foreground { echo Adding node $HOST }
-wait-for-it ${HOST}:22 --timeout=60 --strict -- bash -c "yasetnode ${USERNAME}@$( getent hosts $HOST | awk '{ print $1 }' )"
+wait-for-it ${HOST}:22 --timeout=60 --strict -- bash -c "yasetnode ${USERNAME}@$( getent ahosts $HOST | awk '{ print $1 }' | head -n 1 )"

--- a/compose.yml
+++ b/compose.yml
@@ -9,7 +9,6 @@ services:
       - ./.docker/db/pgcrypto.sql:/docker-entrypoint-initdb.d/10-pgcrypto.sql
 
   adminer:
-    container_name: metis-adminer
     depends_on: ["db"]
     image: docker.io/library/adminer:4
     ports:


### PR DESCRIPTION
Don't use static container names.
Also, use `getent ahosts` for `yanode` name resolving: https://unix.stackexchange.com/questions/50365/getent-hosts-prints-ipv6-getent-ahosts-prints-ipv4