### PR TITLE
Fix container image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/python:3.10-bullseye
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install -y postgresql-client swig wait-for-it xz-utils \
+    && apt-get install -y libboost-dev postgresql-client swig wait-for-it xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
 # setup s6 init


### PR DESCRIPTION
Current state of `docker build`:
```
  × Running setup.py install for xylib-py did not run successfully.
  │ exit code: 1
  ╰─> [29 lines of output]
      running install
      /usr/local/lib/python3.10/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
        warnings.warn(
      running build
      running build_ext
      building '_xylib' extension
      swigging xylib.i to xylib_wrap.cpp
      swig -python -c++ -modern -modernargs -py3 -o xylib_wrap.cpp xylib.i
      Deprecated command line option: -modern. This option is now always on.
      Deprecated command line option: -modernargs. This option is now always on.
      xylib/xylib.h:211: Warning 362: operator= ignored
      xylib/xylib.h:214: Warning 389: operator[] ignored (consider using %extend)
      xylib/xylib.h:71: Warning 451: Setting a const char * variable may leak memory.
      xylib/xylib.h:72: Warning 451: Setting a const char * variable may leak memory.
      xylib/xylib.h:73: Warning 451: Setting a const char * variable may leak memory.
      xylib/xylib.h:76: Warning 451: Setting a const char * variable may leak memory.
      creating build
      creating build/temp.linux-x86_64-cpython-310
      creating build/temp.linux-x86_64-cpython-310/xylib
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/usr/local/include/python3.10 -c xylib_wrap.cpp -o build/temp.linux-x86_64-cpython-310/xylib_wrap.o
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/usr/local/include/python3.10 -c xylib/bruker_raw.cpp -o build/temp.linux-x86_64-cpython-310/xylib/bruker_raw.o
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/usr/local/include/python3.10 -c xylib/bruker_spc.cpp -o build/temp.linux-x86_64-cpython-310/xylib/bruker_spc.o
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I. -I/usr/local/include/python3.10 -c xylib/cache.cpp -o build/temp.linux-x86_64-cpython-310/xylib/cache.o
      In file included from xylib/cache.cpp:5:
      xylib/cache.h:28:10: fatal error: boost/shared_ptr.hpp: No such file or directory
         28 | #include <boost/shared_ptr.hpp>
            |          ^~~~~~~~~~~~~~~~~~~~~~
      compilation terminated.
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: legacy-install-failure
```

Installation of `libboost-dev` package fixes that.