### PR TITLE
build(deps): restrict spglib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ numpy
 scipy
 ase
 pycodcif
-spglib
+spglib <= 2.0.2
 yascheduler
 xylib-py # NB apt-get install libboost-all-dev
 nexusformat


### PR DESCRIPTION
Fix runtime error:
```
INFO:werkzeug:10.89.0.6 - - [02/Feb/2024 16:15:03] "POST /data/create HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 1488, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 1466, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 1463, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 872, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 870, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 855, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/app/metis_backend/helpers.py", line 46, in decorated
    return f(*args, **kwargs)
  File "/app/metis_backend/datasources/bp_data.py", line 106, in create
    ase_obj, error = refine(ase_obj, conventional_cell=True)
  File "/app/metis_backend/structures/struct_utils.py", line 217, in refine
    spg_result = spglib.standardize_cell(
  File "/usr/local/lib/python3.10/site-packages/spglib/spglib.py", line 1305, in standardize_cell
    lattice, _positions, _numbers, _ = _expand_cell(cell)
  File "/usr/local/lib/python3.10/site-packages/spglib/spglib.py", line 1985, in _expand_cell
    lattice = np.array(np.transpose(cell[0]), dtype="double", order="C")
TypeError: float() argument must be a string or a real number, not 'Atom'
```